### PR TITLE
Release for v0.2.0

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    labels:
+      - tagpr

--- a/.tagpr
+++ b/.tagpr
@@ -1,0 +1,42 @@
+# config file for the tagpr in git config format
+# The tagpr generates the initial configuration, which you can rewrite to suit your environment.
+# CONFIGURATIONS:
+#   tagpr.releaseBranch
+#       Generally, it is "main." It is the branch for releases. The tagpr tracks this branch,
+#       creates or updates a pull request as a release candidate, or tags when they are merged.
+#
+#   tagpr.versionFile
+#       Versioning file containing the semantic version needed to be updated at release.
+#       It will be synchronized with the "git tag".
+#       Often this is a meta-information file such as gemspec, setup.cfg, package.json, etc.
+#       Sometimes the source code file, such as version.go or Bar.pm, is used.
+#       If you do not want to use versioning files but only git tags, specify the "-" string here.
+#       You can specify multiple version files by comma separated strings.
+#
+#   tagpr.vPrefix
+#       Flag whether or not v-prefix is added to semver when git tagging. (e.g. v1.2.3 if true)
+#       This is only a tagging convention, not how it is described in the version file.
+#
+#   tagpr.changelog (Optional)
+#       Flag whether or not changelog is added or changed during the release.
+#
+#   tagpr.command (Optional)
+#       Command to change files just before release.
+#
+#   tagpr.template (Optional)
+#       Pull request template in go template format
+#
+#   tagpr.release (Optional)
+#       GitHub Release creation behavior after tagging [true, draft, false]
+#       If this value is not set, the release is to be created.
+#
+#   tagpr.majorLabels (Optional)
+#       Label of major update targets. Default is [major]
+#
+#   tagpr.minorLabels (Optional)
+#       Label of minor update targets. Default is [minor]
+#
+[tagpr]
+	vPrefix = true
+	releaseBranch = main
+	versionFile = -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## [v0.2.0](https://github.com/handlename/let-rds-sleep/compare/v0.1.5...v0.2.0) - 2024-03-15
+- Run single function as both START and STOP mode by @handlename in https://github.com/handlename/let-rds-sleep/pull/2
+
+## [v0.1.5](https://github.com/handlename/let-rds-sleep/compare/v0.1.4...v0.1.5) - 2023-11-20
+- disable cgo by @handlename in https://github.com/handlename/let-rds-sleep/pull/1
+
+## [v0.1.4](https://github.com/handlename/let-rds-sleep/compare/v0.1.3...v0.1.4) - 2023-08-30
+
+## [v0.1.3](https://github.com/handlename/let-rds-sleep/compare/v0.1.2...v0.1.3) - 2023-08-18
+
+## [v0.1.2](https://github.com/handlename/let-rds-sleep/compare/v0.1.1...v0.1.2) - 2022-12-15
+
+## [v0.1.1](https://github.com/handlename/let-rds-sleep/compare/v0.1.0...v0.1.1) - 2022-12-14
+
+## [v0.1.0](https://github.com/handlename/let-rds-sleep/commits/v0.1.0) - 2022-12-14


### PR DESCRIPTION
This pull request is for the next release as v0.2.0 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.2.0 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.5" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
## What's Changed
* Run single function as both START and STOP mode by @handlename in https://github.com/handlename/let-rds-sleep/pull/2


**Full Changelog**: https://github.com/handlename/let-rds-sleep/compare/v0.1.5...v0.2.0