### PR TITLE
Read environment variables as flags

### DIFF
--- a/.tagpr
+++ b/.tagpr
@@ -39,4 +39,4 @@
 [tagpr]
 	vPrefix = true
 	releaseBranch = main
-	versionFile = -
+	versionFile = version.go

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,7 @@
-VERSION = $(shell git describe --tags | head -1)
-
 export CGO_ENABLED=0
 
 let-rds-sleep: go.mod go.sum *.go
-	go build -ldflags "-s -w -X main.version=${VERSION}" -trimpath ./cmd/$@
+	go build -ldflags "-s -w" -trimpath ./cmd/$@
 
 test:
 	go test -v ./...

--- a/app.go
+++ b/app.go
@@ -15,6 +15,12 @@ import (
 	"github.com/samber/lo"
 )
 
+const EnvPrefix = "LET_RDS_SLEEP"
+
+func getEnv(key string) string {
+	return os.Getenv(fmt.Sprintf("%s_%s", EnvPrefix, key))
+}
+
 type App struct {
 	Mode        string
 	TargetTags  []types.Tag // only resources having all of tags will be process
@@ -53,7 +59,7 @@ func (r Resource) TagsAsString() string {
 type Option func(app *App) error
 
 func init() {
-	logLevel := strings.ToUpper(os.Getenv("LOG_LEVEL"))
+	logLevel := strings.ToUpper(getEnv("LOG_LEVEL"))
 	if logLevel == "" {
 		logLevel = "INFO"
 	}

--- a/cli.go
+++ b/cli.go
@@ -25,7 +25,12 @@ type CLIFlags struct {
 }
 
 func RunCLI() int {
-	flags := parseCLIFlags()
+	flags, err := parseCLIFlags(os.Args[1:])
+	if err != nil {
+		log.Printf("failed to parse flags: %s", err)
+		return ExitStatusError
+	}
+
 	if err := validateCLIFlags(flags); err != nil {
 		log.Printf("failed to validate flags: %s", err)
 		return ExitStatusError
@@ -51,30 +56,34 @@ func isLambda() bool {
 		os.Getenv("AWS_LAMBDA_RUNTIME_API") != ""
 }
 
-func parseCLIFlags() *CLIFlags {
+func parseCLIFlags(args []string) (*CLIFlags, error) {
 	flags := &CLIFlags{}
 
-	flag.StringVar(&flags.Mode, "mode", "", "STOP or START, only for oneshot mode")
-	flag.StringVar(&flags.Target, "target", "", "TagName=Value,... If no tags given, treat all of resources as target")
-	flag.StringVar(&flags.Exclude, "exclude", "", "TagName=Value,... If Tag exists exclude the resource")
-	flag.BoolVar(&flags.DryRun, "dryrun", false, "show process target only")
-	flag.BoolVar(&flags.Version, "version", false, "display version")
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
+	fs.StringVar(&flags.Mode, "mode", "", "STOP or START, only for oneshot mode")
+	fs.StringVar(&flags.Target, "target", "", "TagName=Value,... If no tags given, treat all of resources as target")
+	fs.StringVar(&flags.Exclude, "exclude", "", "TagName=Value,... If Tag exists exclude the resource")
+	fs.BoolVar(&flags.DryRun, "dryrun", false, "show process target only")
+	fs.BoolVar(&flags.Version, "version", false, "display version")
 
 	// overwrite by environment variables
-	flag.VisitAll(func(f *flag.Flag) {
+	fs.VisitAll(func(f *flag.Flag) {
 		if env := getEnv(strings.ToUpper(f.Name)); env != "" {
 			f.Value.Set(env)
 		}
 	})
 
-	flag.Parse()
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
 
-	return flags
+	return flags, nil
 }
 
 func validateCLIFlags(flags *CLIFlags) error {
 	if isLambda() && flags.Mode != "" {
-		return fmt.Errorf("-mode option is only available in Lambda mode")
+		return fmt.Errorf("-mode option is only available in oneshot mode")
 	}
 
 	return nil

--- a/cli.go
+++ b/cli.go
@@ -1,0 +1,87 @@
+package lrs
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/aws/aws-lambda-go/lambda"
+)
+
+var (
+	version string
+)
+
+const (
+	ExitStatusOK    = 0
+	ExitStatusError = 1
+)
+
+func RunCLI() int {
+	var (
+		flagMode    string
+		flagTarget  string
+		flagExclude string
+		flagDryRun  bool
+		flagVersion bool
+	)
+
+	flag.StringVar(&flagMode, "mode", "", "STOP or START, only for oneshot mode")
+	flag.StringVar(&flagTarget, "target", "", "TagName=Value,... If no tags given, treat all of resources as target")
+	flag.StringVar(&flagExclude, "exclude", "", "TagName=Value,... If Tag exists exclude the resource")
+	flag.BoolVar(&flagDryRun, "dryrun", false, "show process target only")
+	flag.BoolVar(&flagVersion, "version", false, "display version")
+	flag.Parse()
+
+	if flagVersion {
+		fmt.Printf("let-rds-sleep %s", version)
+		return ExitStatusError
+	}
+
+	app, err := New(
+		OptTarget(flagTarget),
+		OptExclude(flagExclude),
+		OptDryRun(flagDryRun),
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to init app: %s", err)
+		return ExitStatusError
+	}
+
+	if strings.HasPrefix(os.Getenv("AWS_EXECUTION_ENV"), "AWS_Lambda") || os.Getenv("AWS_LAMBDA_RUNTIME_API") != "" {
+		if flagMode != "" {
+			fmt.Fprintf(os.Stderr, "-mode option is not available in Lambda mode")
+		}
+
+		fmt.Println("started as Lambda function handler")
+		lambda.Start(app.HandleRequest)
+	} else {
+		fmt.Println("started as oneshot mode")
+
+		var mode string
+		switch strings.ToUpper(flagMode) {
+		case "STOP":
+			mode = ModeStop
+		case "START":
+			mode = ModeStart
+		default:
+			fmt.Fprintf(os.Stderr, "invalid mode: %s", flagMode)
+			return ExitStatusError
+		}
+
+		if err := app.Run(context.Background(), mode); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to Run: %s", err)
+			return ExitStatusError
+		}
+	}
+
+	fmt.Println("bye")
+
+	return ExitStatusOK
+}
+
+func parseCLIArgs() {
+
+}

--- a/cli.go
+++ b/cli.go
@@ -4,14 +4,11 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"strings"
 
 	"github.com/aws/aws-lambda-go/lambda"
-)
-
-var (
-	version string
 )
 
 const (
@@ -19,69 +16,92 @@ const (
 	ExitStatusError = 1
 )
 
-func RunCLI() int {
-	var (
-		flagMode    string
-		flagTarget  string
-		flagExclude string
-		flagDryRun  bool
-		flagVersion bool
-	)
+type CLIFlags struct {
+	Mode    string
+	Target  string
+	Exclude string
+	DryRun  bool
+	Version bool
+}
 
-	flag.StringVar(&flagMode, "mode", "", "STOP or START, only for oneshot mode")
-	flag.StringVar(&flagTarget, "target", "", "TagName=Value,... If no tags given, treat all of resources as target")
-	flag.StringVar(&flagExclude, "exclude", "", "TagName=Value,... If Tag exists exclude the resource")
-	flag.BoolVar(&flagDryRun, "dryrun", false, "show process target only")
-	flag.BoolVar(&flagVersion, "version", false, "display version")
+func RunCLI() int {
+	flags := parseCLIFlags()
+	if err := validateCLIFlags(flags); err != nil {
+		log.Printf("failed to validate flags: %s", err)
+		return ExitStatusError
+	}
+
+	if flags.Version {
+		fmt.Printf("let-rds-sleep %s", version)
+		return ExitStatusOK
+	}
+
+	if err := runApp(flags); err != nil {
+		log.Printf("[INFO] failed to run: %s", err)
+		return ExitStatusError
+	}
+
+	log.Println("[INFO] bye")
+
+	return ExitStatusOK
+}
+
+func isLambda() bool {
+	return strings.HasPrefix(os.Getenv("AWS_EXECUTION_ENV"), "AWS_Lambda") ||
+		os.Getenv("AWS_LAMBDA_RUNTIME_API") != ""
+}
+
+func parseCLIFlags() *CLIFlags {
+	flags := &CLIFlags{}
+
+	flag.StringVar(&flags.Mode, "mode", "", "STOP or START, only for oneshot mode")
+	flag.StringVar(&flags.Target, "target", "", "TagName=Value,... If no tags given, treat all of resources as target")
+	flag.StringVar(&flags.Exclude, "exclude", "", "TagName=Value,... If Tag exists exclude the resource")
+	flag.BoolVar(&flags.DryRun, "dryrun", false, "show process target only")
+	flag.BoolVar(&flags.Version, "version", false, "display version")
 	flag.Parse()
 
-	if flagVersion {
-		fmt.Printf("let-rds-sleep %s", version)
-		return ExitStatusError
+	return flags
+}
+
+func validateCLIFlags(flags *CLIFlags) error {
+	if isLambda() && flags.Mode != "" {
+		return fmt.Errorf("-mode option is only available in Lambda mode")
 	}
 
+	return nil
+}
+
+func runApp(flags *CLIFlags) error {
 	app, err := New(
-		OptTarget(flagTarget),
-		OptExclude(flagExclude),
-		OptDryRun(flagDryRun),
+		OptTarget(flags.Target),
+		OptExclude(flags.Exclude),
+		OptDryRun(flags.DryRun),
 	)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to init app: %s", err)
-		return ExitStatusError
+		return fmt.Errorf("failed to init app: %s", err)
 	}
 
-	if strings.HasPrefix(os.Getenv("AWS_EXECUTION_ENV"), "AWS_Lambda") || os.Getenv("AWS_LAMBDA_RUNTIME_API") != "" {
-		if flagMode != "" {
-			fmt.Fprintf(os.Stderr, "-mode option is not available in Lambda mode")
-		}
-
-		fmt.Println("started as Lambda function handler")
+	if isLambda() {
+		log.Println("[INFO] started as Lambda function handler")
 		lambda.Start(app.HandleRequest)
 	} else {
-		fmt.Println("started as oneshot mode")
+		log.Println("[INFO] started as oneshot mode")
 
 		var mode string
-		switch strings.ToUpper(flagMode) {
+		switch strings.ToUpper(flags.Mode) {
 		case "STOP":
 			mode = ModeStop
 		case "START":
 			mode = ModeStart
 		default:
-			fmt.Fprintf(os.Stderr, "invalid mode: %s", flagMode)
-			return ExitStatusError
+			return fmt.Errorf("invalid mode: %s", flags.Mode)
 		}
 
 		if err := app.Run(context.Background(), mode); err != nil {
-			fmt.Fprintf(os.Stderr, "failed to Run: %s", err)
-			return ExitStatusError
+			return fmt.Errorf("failed to Run: %s", err)
 		}
 	}
 
-	fmt.Println("bye")
-
-	return ExitStatusOK
-}
-
-func parseCLIArgs() {
-
+	return nil
 }

--- a/cli.go
+++ b/cli.go
@@ -59,6 +59,14 @@ func parseCLIFlags() *CLIFlags {
 	flag.StringVar(&flags.Exclude, "exclude", "", "TagName=Value,... If Tag exists exclude the resource")
 	flag.BoolVar(&flags.DryRun, "dryrun", false, "show process target only")
 	flag.BoolVar(&flags.Version, "version", false, "display version")
+
+	// overwrite by environment variables
+	flag.VisitAll(func(f *flag.Flag) {
+		if env := getEnv(strings.ToUpper(f.Name)); env != "" {
+			f.Value.Set(env)
+		}
+	})
+
 	flag.Parse()
 
 	return flags

--- a/cli_test.go
+++ b/cli_test.go
@@ -1,0 +1,84 @@
+package lrs
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestParseCLIFlags(t *testing.T) {
+	tests := []struct {
+		title string
+		args  []string
+		envs  map[string]string
+		want  *CLIFlags
+	}{
+		{
+			title: "default",
+			args: []string{
+				"-mode", "stop",
+			},
+			want: &CLIFlags{
+				Mode:    "stop",
+				Target:  "",
+				Exclude: "",
+				DryRun:  false,
+			},
+		},
+		{
+			title: "args only",
+			args: []string{
+				"-mode", "stop",
+				"-target", "tag:Name=foo",
+				"-exclude", "tag:Name=bar",
+				"-dryrun",
+			},
+			want: &CLIFlags{
+				Mode:    "stop",
+				Target:  "tag:Name=foo",
+				Exclude: "tag:Name=bar",
+				DryRun:  true,
+			},
+		},
+		{
+			title: "args override envs",
+			args: []string{
+				"-mode", "stop",
+				"-target", "tag:Name=foo",
+			},
+			envs: map[string]string{
+				"LET_RDS_SLEEP_MODE":    "start",
+				"LET_RDS_SLEEP_EXCLUDE": "tag:Name=bar",
+			},
+			want: &CLIFlags{
+				Mode:    "stop",
+				Target:  "tag:Name=foo",
+				Exclude: "tag:Name=bar",
+				DryRun:  false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.title, func(t *testing.T) {
+			flag.CommandLine = flag.NewFlagSet("let-rds-sleep", flag.ExitOnError)
+
+			if tt.envs != nil {
+				for k, v := range tt.envs {
+					t.Setenv(k, v)
+				}
+			}
+
+			got, err := parseCLIFlags(tt.args)
+			if err != nil {
+				t.Errorf("unexpected error: %s", err)
+
+			}
+
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("unexpected result: %s", diff)
+			}
+		})
+	}
+}

--- a/cmd/let-rds-sleep/main.go
+++ b/cmd/let-rds-sleep/main.go
@@ -1,77 +1,11 @@
 package main
 
 import (
-	"context"
-	"flag"
-	"fmt"
 	"os"
-	"strings"
 
-	"github.com/aws/aws-lambda-go/lambda"
 	lrs "github.com/handlename/let-rds-sleep"
 )
 
-var (
-	version string
-)
-
 func main() {
-	var (
-		flagMode    string
-		flagTarget  string
-		flagExclude string
-		flagDryRun  bool
-		flagVersion bool
-	)
-
-	flag.StringVar(&flagMode, "mode", "", "STOP or START, only for oneshot mode")
-	flag.StringVar(&flagTarget, "target", "", "TagName=Value,... If no tags given, treat all of resources as target")
-	flag.StringVar(&flagExclude, "exclude", "", "TagName=Value,... If Tag exists exclude the resource")
-	flag.BoolVar(&flagDryRun, "dryrun", false, "show process target only")
-	flag.BoolVar(&flagVersion, "version", false, "display version")
-	flag.Parse()
-
-	if flagVersion {
-		fmt.Printf("let-rds-sleep %s", version)
-		os.Exit(0)
-	}
-
-	app, err := lrs.New(
-		lrs.OptTarget(flagTarget),
-		lrs.OptExclude(flagExclude),
-		lrs.OptDryRun(flagDryRun),
-	)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to init app: %s", err)
-		os.Exit(1)
-	}
-
-	if strings.HasPrefix(os.Getenv("AWS_EXECUTION_ENV"), "AWS_Lambda") || os.Getenv("AWS_LAMBDA_RUNTIME_API") != "" {
-		if flagMode != "" {
-			fmt.Fprintf(os.Stderr, "-mode option is not available in Lambda mode")
-		}
-
-		fmt.Println("started as Lambda function handler")
-		lambda.Start(app.HandleRequest)
-	} else {
-		fmt.Println("started as oneshot mode")
-
-		var mode string
-		switch strings.ToUpper(flagMode) {
-		case "STOP":
-			mode = lrs.ModeStop
-		case "START":
-			mode = lrs.ModeStart
-		default:
-			fmt.Fprintf(os.Stderr, "invalid mode: %s", flagMode)
-			os.Exit(1)
-		}
-
-		if err := app.Run(context.Background(), mode); err != nil {
-			fmt.Fprintf(os.Stderr, "failed to Run: %s", err)
-			os.Exit(1)
-		}
-	}
-
-	fmt.Println("bye")
+	os.Exit(lrs.RunCLI())
 }

--- a/version.go
+++ b/version.go
@@ -1,0 +1,3 @@
+package lrs
+
+const version = "0.2.0"


### PR DESCRIPTION
`LET_LDS_SLEEP_{flag}`

environment variable `LET_RDS_SLEEP_MODE=start` is equivalent to flag `-mode=start`