### PR TITLE
Release for v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [v0.3.1](https://github.com/handlename/let-rds-sleep/compare/v0.3.0...v0.3.1) - 2024-04-25
+
 ## [v0.3.0](https://github.com/handlename/let-rds-sleep/compare/v0.2.0...v0.3.0) - 2024-04-25
 - Read environment variables as flags by @handlename in https://github.com/handlename/let-rds-sleep/pull/4
 - Run test on GitHub Actions by @handlename in https://github.com/handlename/let-rds-sleep/pull/6

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package lrs
 
-const version = "0.3.0"
+const version = "0.3.1"


### PR DESCRIPTION
This pull request is for the next release as v0.3.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.3.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.3.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->



**Full Changelog**: https://github.com/handlename/let-rds-sleep/compare/v0.3.0...v0.3.1